### PR TITLE
Implement configuration based on sysconfig_proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,13 @@ travis-ci = { repository = "mattico/proxy-config" }
 [dependencies]
 url = "1.5"
 
+[dev-dependencies]
+tempfile = "2.1.6"
+
 [features]
-default = ["env"]
+default = ["env", "sysconfig_proxy"]
 env = []
+sysconfig_proxy = []
 
 [target."cfg(windows)".dependencies]
 winreg = "0.4"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use std::fmt;
+use std::io;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum ProxyConfigError {
@@ -10,6 +11,7 @@ pub enum ProxyConfigError {
     OsError,
     PlatformNotSupportedError,
     ProxyTypeNotSupportedError(String),
+    ConfigurationNotReadableError,
 }
 use ProxyConfigError::*;
 pub type Result<T> = ::std::result::Result<T, ProxyConfigError>;
@@ -24,6 +26,7 @@ impl Error for ProxyConfigError {
             OsError => "error getting proxy configuration from the Operating System",
             PlatformNotSupportedError => "can not read proxy configuration on this platform",
             ProxyTypeNotSupportedError(_) => "proxy type not supported",
+            ConfigurationNotReadableError => "Could not read configuration file",
         }
     }
 }
@@ -41,5 +44,11 @@ impl fmt::Display for ProxyConfigError {
 impl From<::url::ParseError> for ProxyConfigError {
     fn from(_error: ::url::ParseError) -> Self {
         InvalidConfigError
+    }
+}
+
+impl From<io::Error> for ProxyConfigError {
+    fn from(_error: io::Error) -> Self {
+        ConfigurationNotReadableError
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ mod windows;
 #[cfg(feature = "env")]
 mod env;
 
+#[cfg(feature = "sysconfig_proxy")]
+mod sysconfig_proxy;
+
 mod errors;
 mod util;
 
@@ -29,6 +32,8 @@ type ProxyFn = fn() -> Result<ProxyConfig>;
 const METHODS: &[&ProxyFn] = &[
     #[cfg(feature = "env")]
     &(env::get_proxy_config as ProxyFn),
+    #[cfg(feature = "sysconfig_proxy")]
+    &(sysconfig_proxy::get_proxy_config as ProxyFn), //This configurator has to come after the `env` configurator, because environment variables take precedence over /etc/sysconfig/proxy
     #[cfg(windows)]
     &(windows::get_proxy_config as ProxyFn),
 ];

--- a/src/sysconfig_proxy.rs
+++ b/src/sysconfig_proxy.rs
@@ -1,5 +1,5 @@
 
-//! This module reads the proxy configuration file /etc/sysconfig_proxy which 
+//! This module reads the proxy configuration file /etc/sysconfig/proxy which 
 //! exists on Red Hat Enterprise Linux and related Linux systems. For a
 //! description of the configuration file format see:
 //! https://www.novell.com/support/kb/doc.php?id=7006845
@@ -11,7 +11,7 @@ use std::io::{BufRead,BufReader};
 
 use super::*;
 
-/// Extract proxy information from /etc/sysconfig_proxy if the file is available
+/// Extract proxy information from /etc/sysconfig/proxy if the file is available
 /// and formatted correctly. If the file is not available or if there are any
 /// other IO erros, an ConfigurationNotReadableError error will be returned.
 pub(crate) fn get_proxy_config() -> Result<ProxyConfig> {
@@ -183,7 +183,7 @@ PROXY_ENABLED="yes""##);
     #[test]
     fn test_whitelist() {
         // It would be nicer to test this directly with get_proxy_for_url() but
-        // then we would need to overwrite /etc/sysconfig_proxy which is
+        // then we would need to overwrite /etc/sysconfig/proxy which is
         // something a unit test should not do.
 
         let file = spit(r##"HTTP_PROXY="http://1.2.3.4"

--- a/src/sysconfig_proxy.rs
+++ b/src/sysconfig_proxy.rs
@@ -1,0 +1,239 @@
+
+//! This module reads the proxy configuration file /etc/sysconfig_proxy which 
+//! exists on Red Hat Enterprise Linux and related Linux systems. For a
+//! description of the configuration file format see:
+//! https://www.novell.com/support/kb/doc.php?id=7006845
+//! https://www.suse.com/de-de/support/kb/doc/?id=7006845
+
+use std::path::Path;
+use std::fs::File;
+use std::io::{BufRead,BufReader};
+
+use super::*;
+
+/// Extract proxy information from /etc/sysconfig_proxy if the file is available
+/// and formatted correctly. If the file is not available or if there are any
+/// other IO erros, an ConfigurationNotReadableError error will be returned.
+pub(crate) fn get_proxy_config() -> Result<ProxyConfig> {
+    get_proxy_config_from_file("/etc/sysconfig/proxy")
+}
+
+/// The same as get_proxy_config() but this function expects a file's path as an
+/// argument.
+fn get_proxy_config_from_file<P: AsRef<Path>>(config_file: P) -> Result<ProxyConfig> {
+    let map = read_key_value_pairs_from_file(config_file)?;
+    if let Some(enabled) = map.get("PROXY_ENABLED") {
+        match enabled.as_str() {
+            "yes" => (), //continue running this function
+            "no"  => return Err(NoProxyNeededError),
+            _ => return Err(InvalidConfigError), //consider all other values as illegal
+        }
+    } else {
+        return Err(InvalidConfigError) //missing PROXY_ENABLED directive
+    }
+
+    let mut proxies: HashMap<String,Url> = HashMap::new();
+    let mut whitelist: Vec<String> = Vec::new();
+
+    // determine the proxies
+    let schemes = [ "HTTP", "HTTPS", "FTP" ];
+    for scheme in schemes.iter() {
+        let key = String::from(*scheme) + "_PROXY";
+        if let Some(proxy) = map.get(&key) { //check if ${SCHEME}_PROXY is defined
+            let scheme = scheme.to_lowercase();
+            let address_scheme = util::parse_addr_default_scheme(&scheme, &proxy)?;
+            proxies.insert(scheme.into(), address_scheme);
+        }
+    }
+
+    // determine the list of domains that should not be requested through the proxy
+    if let Some(no_proxy) = map.get("NO_PROXY") {
+        for no_proxy_url in no_proxy.split(",") {
+            whitelist.push(no_proxy_url.trim().into())
+        }
+    }
+
+    if proxies.is_empty() {
+        Err(NoProxyConfiguredError)
+    } else {
+        Ok(ProxyConfig {
+           proxies,
+           whitelist,
+           ..Default::default()
+        })
+    }
+}
+
+/// Read a file which contains key-value pairs that are separated by an equals
+/// sign and each value has to be surrounded by double quotes.. Each key-value
+/// pair has to be on it's own line. Example:
+///
+/// ```plain
+/// foo="42"
+/// bar="43"
+///
+/// baz="44"
+/// quux="foobar"
+/// ```
+///
+/// The file may contain empty lines. Values in double quotes will be converted
+/// into values without the outer double quotes.
+///
+/// Note that the current implementation does not trim whitespace and the ends
+/// of a line. It is currently assumed that leading or trailing whitespace is
+/// not part of the file format.
+///
+fn read_key_value_pairs_from_file<P: AsRef<Path>>(file: P) -> Result<HashMap<String,String>> {
+    let mut result = HashMap::new();
+    let file = File::open(file)?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?; //get rid of IO errors
+
+        if line.is_empty() {
+            continue //skip empty line
+        }
+
+        if let Some(pos) = line.find("=\"") {
+            let key = line[0..pos].to_string();
+            let value = strip_after_quote(&line[pos+2..]).to_string();
+            result.insert(key,value);
+        } else { //there has to be an equals sign in this file.
+            return Err(InvalidConfigError)
+        }
+    }
+
+    Ok(result)
+}
+
+/// Remove trailing double quote (and anything thereafter) from a string
+fn strip_after_quote(s: &str) -> &str {
+    match s.find('"') { //we will tolerate more trailing quaracters after a quote
+        Some(pos) => &s[..pos], //+1 because the rfind() call was on a 1-shifted slice
+        None => &s //Be generous and assume that there should have been a double quote at the very end
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    extern crate tempfile;
+
+    use super::*;
+    use std::io::{Write};
+    use self::tempfile::NamedTempFile;
+
+
+    /// write a string to a temporary file
+    fn spit(contents: &str) -> NamedTempFile {
+        let mut outfile = NamedTempFile::new().expect("failed to create temporary file");
+        //let mut outfile = File::create(location).unwrap();
+        let _ = outfile.write(contents.as_bytes());
+        outfile
+    }
+
+    #[test]
+    fn test_read_key_value_pairs_from_file() {
+        let file = spit(r##"
+foo="bar"
+baz="quux"
+
+spam="eggs"
+
+"##);
+        let map = read_key_value_pairs_from_file(file.path()).unwrap();
+        assert!(map.get("foo").unwrap() == "bar");
+        assert!(map.get("baz").unwrap() == "quux");
+        assert!(map.get("spam").unwrap() == "eggs");
+
+        let file = spit(r##"
+foo="bar"
+baz "quux"
+
+spam="eggs"
+
+"##);
+        assert!(read_key_value_pairs_from_file(file.path()).is_err());
+    }
+
+    #[test]
+    fn test_get_proxy_config() {
+        let file = spit(r##"HTTP_PROXY="http://1.2.3.4"
+HTTPS_PROXY="https://1.2.3.4:8000""##);
+        assert_eq!(get_proxy_config_from_file(file.path()),
+                   Err(InvalidConfigError)); //missing PROXY_enabled
+
+        let file = spit(
+r##"HTTP_PROXY="http://1.2.3.4"
+HTTPS_PROXY="https://1.2.3.4:8000"
+PROXY_ENABLED="no""##);
+        assert_eq!(get_proxy_config_from_file(file.path()),
+                   Err(NoProxyNeededError));
+
+        let file = spit(r##"HTTP_PROXY="http://1.2.3.4"
+HTTPS_PROXY="https://1.2.3.4:8000"
+PROXY_ENABLED="yes""##);
+        let config = get_proxy_config_from_file(file.path()).unwrap();
+        assert_eq!(config.proxies.get("http").unwrap(),
+                   &Url::parse("http://1.2.3.4").unwrap());
+        assert_eq!(config.proxies.get("https").unwrap(),
+                   &Url::parse("https://1.2.3.4:8000").unwrap());
+    }
+
+    #[test]
+    fn test_whitelist() {
+        // It would be nicer to test this directly with get_proxy_for_url() but
+        // then we would need to overwrite /etc/sysconfig_proxy which is
+        // something a unit test should not do.
+
+        let file = spit(r##"HTTP_PROXY="http://1.2.3.4"
+HTTPS_PROXY="https://1.2.3.4:8000"
+NO_PROXY="localhost,1.2.3.4,5.6.7.8"
+PROXY_ENABLED="yes""##);
+        let config = get_proxy_config_from_file(file.path()).unwrap();
+        for no_proxy in config.whitelist {
+            match no_proxy.as_str() {
+                "localhost" => (),
+                "1.2.3.4" => (),
+                "5.6.7.8" => (),
+                _ => Err(()).expect("Expecting no proxy element to be one of \"localhost\", \"1.2.3.4\" or \"5.6.7.8\"")
+            }
+        }
+    }
+
+    #[test]
+    fn test_unquote() {
+        assert_eq!(strip_after_quote("foo"),"foo");
+        assert_eq!(strip_after_quote("\"foo\""),"");
+        assert_eq!(strip_after_quote("\"foo bar"),"");
+        assert_eq!(strip_after_quote("foo\"bar"),"foo");
+    }
+
+    #[test]
+    fn test_with_example_from_specification() {
+        let file = spit(r##"
+PROXY_ENABLED="yes"
+
+HTTP_PROXY="http://192.168.0.1"
+HTTPS_PROXY="http://192.168.0.1"
+FTP_PROXY="http://192.168.0.1"
+NO_PROXY="localhost, 127.0.0.1"
+"##);
+    let config = get_proxy_config_from_file(file.path()).unwrap();
+    assert_eq!(config.proxies.get("http").unwrap(), &Url::parse("http://192.168.0.1").unwrap());
+    assert_eq!(config.proxies.get("https").unwrap(), &Url::parse("http://192.168.0.1").unwrap());
+    assert_eq!(config.proxies.get("ftp").unwrap(), &Url::parse("http://192.168.0.1").unwrap());
+    assert!(config.whitelist.contains(&"localhost".to_string()));
+    assert!(config.whitelist.contains(&"127.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn test_file_without_quoting() {
+        let file = spit(r##"PROXY_ENABLED="yes"
+HTTP_PROXY=http://localhost"##);
+        match  get_proxy_config_from_file(file.path()) {
+            Err(InvalidConfigError) => (), //all is fine
+            _ => assert!(false)
+        }
+    }
+}


### PR DESCRIPTION
The implementation conforms to the standard described on the web sites:
https://www.suse.com/de-de/support/kb/doc/?id=7006845
https://www.novell.com/support/kb/doc.php?id=7006845

fixes mattico/proxy-config#5